### PR TITLE
Doc edits

### DIFF
--- a/qos_bandwidth.adoc
+++ b/qos_bandwidth.adoc
@@ -30,7 +30,7 @@ The reset value is `UNSPECIFIED` for all other register fields.
 
 The bandwidth controllers at reset must allocate all available bandwidth to
 `RCID` value of 0. When the bandwidth controller supports bandwidth allocation
-per access-type, the access-type value of 0 of `RCID=0` is allocated to all
+per access-type, the access-type value of 0 of `RCID=0` is allocated all
 available bandwidth, while all other access-types associated with that `RCID`
 share the bandwidth allocation with `AT=0`. The bandwidth allocation for all
 other `RCID` values is `UNSPECIFIED`. The bandwidth controller behavior in

--- a/qos_bandwidth.adoc
+++ b/qos_bandwidth.adoc
@@ -30,7 +30,7 @@ The reset value is `UNSPECIFIED` for all other register fields.
 
 The bandwidth controllers at reset must allocate all available bandwidth to
 `RCID` value of 0. When the bandwidth controller supports bandwidth allocation
-per access-type, the access-type value of 0 of `RCID=0` is allocated all
+per access-type, the access-type value of 0 of `RCID=0` is allocated to all
 available bandwidth, while all other access-types associated with that `RCID`
 share the bandwidth allocation with `AT=0`. The bandwidth allocation for all
 other `RCID` values is `UNSPECIFIED`. The bandwidth controller behavior in
@@ -63,7 +63,7 @@ The `VER` field holds the version of the specification implemented by the
 bandwidth controller. The low nibble is used to hold the minor version of the
 specification and the upper nibble is used to hold the major version of the
 specification. For example, an implementation that supports version 1.0 of the
-specification reports 0x10.
+specification reports `0x10`.
 
 The `NBWBLKS` field holds the total number of available bandwidth blocks in 
 the controller. The bandwidth represented by each bandwidth block is
@@ -71,16 +71,16 @@ the controller. The bandwidth represented by each bandwidth block is
 multiples of a bandwidth block, which enables proportional allocation of
 bandwidth.
 
-Bandwidth controllers may limit the maximum bandwidth that may be reserved to
-a value smaller than `NBWBLKS`. The `MRBWB` field reports the maximum number of
+Bandwidth controllers can limit the maximum bandwidth that can be reserved to
+a value smaller than the `NBWBLKS` value. The `MRBWB` field reports the maximum number of
 bandwidth blocks that can be reserved.
 
 [NOTE]
 ====
-The bandwidth controller needs to meter the bandwidth usage by a workload to
-determine if it is exceeding its allocations and, if necessary, take necessary
+The bandwidth controller meters the bandwidth usage by a workload to
+determine if it is exceeding its allocations and, if necessary, take 
 measures to throttle the workload's bandwidth usage. Therefore, the instantaneous
-bandwidth used by a workload may either exceed or fall short of  the configured
+bandwidth used by a workload either exceeds or falls short of the configured
 allocation. QoS capabilities are statistical in nature and are typically
 designed to enforce the configured bandwidth over larger time windows. By not
 allowing all available bandwidth blocks to be reserved for allocation, the
@@ -89,14 +89,14 @@ bandwidth controller can handle such transient inaccuracies.
 
 If `RPFX` is 1, the controller uses `RCID` in the requests along with `P` least
 significant bits of the `MCID` carried in the request to compute an effective
-`MCID` (<<EMCID>>) to identify the monitoring counter. Legal values of `P` range
+`MCID` (<<EMCID>>) to identify the monitoring counter. Valid values of `P` range
 from 0 to 12. If `RPFX` is 0, `P` is set to 0, and the effective `MCID` is the
 same as the `MCID` in the request.
 
 [[BC_MCTL]]
 === Bandwidth Usage Monitoring Control
 
-The `bc_mon_ctl` register is used to control monitoring of bandwidth usage by a
+The `bc_mon_ctl` register controls the monitoring of bandwidth usage by a
 `MCID`. When the controller does not support bandwidth usage monitoring, the
 `bc_mon_ctl` register is read-only zero.
 
@@ -117,10 +117,10 @@ The `bc_mon_ctl` register is used to control monitoring of bandwidth usage by a
 ....
 
 Bandwidth controllers that support bandwidth usage monitoring implement a usage
-monitoring counter for each supported `MCID`. The usage monitoring counter may
+monitoring counter for each supported `MCID`. The usage monitoring counter might
 be configured to count a monitoring event. When an event matching the event
-configured for the `MCID` occurs then the monitoring counter is updated. The
-event matching may optionally be filtered by the access-type. The monitoring 
+configured for the `MCID` occurs, then the monitoring counter is updated. The
+event matching can optionally be filtered by the access-type. The monitoring 
 counter for bandwidth usage counts the number of bytes transferred by requests
 matching the monitoring event as the requests go past the monitoring point.
 
@@ -149,8 +149,8 @@ listed in <<BC_MON_OP>>.
 | --           | 24-31     | Designated for custom use.
 |===
 
-The `EVT_ID` field is used to program, using the `CONFIG_EVENT` operation, the
-identifier of the event to count in the monitoring counter selected by `MCID`.
+The `EVT_ID` field uses the `CONFIG_EVENT` operation to program the
+identifier of the event to count in the monitoring counter, selected by `MCID`.
 The `AT` field is used to program the access-type to count, and its validity is
 indicated by the `ATV` field. When `ATV` is 0, the counter counts requests with
 all access-types, and the `AT` value is ignored.
@@ -190,8 +190,8 @@ all access-types.
 
 When the `bc_mon_ctl` register is written, the controller may need to perform
 several actions that may not complete synchronously with the write. A write to
-the `bc_mon_ctl` sets the read-only `BUSY` bit to 1 indicating the controller
-is performing the requested operation. When the `BUSY` bit reads 0, the
+the `bc_mon_ctl` register sets the read-only `BUSY` bit to 1, indicating that the 
+controller is performing the requested operation. When the `BUSY` bit reads 0, the
 operation is complete, and the read-only `STATUS` field provides a status value
 (see <<BC_MON_STS>> for details). Written values to the `BUSY` and the `STATUS`
 fields are ignored. An implementation that can complete the operation
@@ -378,9 +378,9 @@ The `bc_bw_alloc` holds the previously configured reserved bandwidth blocks for
 an `RCID` and `AT` on successful completion of the `READ_LIMIT` operation.
 
 Bandwidth is allocated in multiples of bandwidth blocks, and the value in `Rbwb`
-must be at least 1 and must not exceed `MRBWB`. Otherwise, the `CONFIG_LIMIT`
+must be at least 1 and must not exceed `MRBWB` value. Otherwise, the `CONFIG_LIMIT`
 operation fails with `STATUS=5`. Additionally, the sum of `Rbwb` allocated
-across all `RCIDs` must not exceed `MRBWB`, or the `CONFIG_LIMIT` operation
+across all `RCIDs` must not exceed `MRBWB` value, or the `CONFIG_LIMIT` operation
 fails with `STATUS=5`.
 
 .Bandwidth Allocation Configuration Register (`bc_bw_alloc`)
@@ -400,30 +400,30 @@ The `Rbwb`, `Mweight`, `sharedAT`, and `useShared` are all WARL fields.
 
 Bandwidth allocation is typically enforced by the bandwidth controller over
 finite accounting windows. The process involves measuring the bandwidth
-consumption over an accounting window and using the measured bandwidth to
-determine if an `RCID` is exceeding its bandwidth allocations for each
-access-types. The specifics of how the accounting window is implemented are
-`UNSPECIFIED`, but is expected to provide a statistically accurate control of 
-the bandwidth usage over a few accounting intervals.
+consumption over an accounting window and determining if an `RCID` is exceeding 
+its bandwidth allocations for each access-types. The specifics of how the 
+accounting window is implemented are `UNSPECIFIED`, but is expected to provide 
+a statistically accurate control of the bandwidth usage over a few accounting 
+intervals.
 
-The `Rbwb` represents the bandwidth that is made available to a `RCID` for
-requests matching `AT`, even when all other `RCID` are using their full
+The `Rbwb` field represents the bandwidth that is made available to an `RCID` for
+requests that match `AT`, even when all other `RCID` are using their full
 allocation of bandwidth. The bandwidth allocation scales linearly with the
 number of bandwidth blocks programmed into `Rbwb`.
 
 If there is non-reserved or unused bandwidth available in an accounting
 interval, `RCIDs` may compete for additional bandwidth. The non-reserved or
-unused bandwidth is proportionately shared among the competing `RCIDs` using the
+unused bandwidth is proportionately shared among the competing `RCIDs` by using the
 configured `Mweight` parameter, which is a number between 0 and 255. A larger
 weight implies a greater fraction of the bandwidth. A weight of 0 implies that
 the configured limit is a hard limit, and the use of unused or non-reserved
 bandwidth is not allowed.
 
-The sharing of non-reserved bandwidth is not differentiated by access-type.
+Sharing of non-reserved bandwidth is not differentiated by access-type identifier.
 Therefore, the `Mweight` parameter must be programmed identically for all
-access-types. If this parameter is programmed differently for each access-type,
-then the controller may use the parameter configured for any of the
-access-types, but the behavior is otherwise well defined.
+access-type identifiers. If this parameter is programmed differently for each access-type 
+identifier, then the controller can use the parameter configured for any of the
+identifiers, but the behavior is otherwise well defined.
 
 When the `Mweight` parameter is not set to 0, the amount of unused bandwidth
 allocated to `RCID=x` during contention with another `RCID` that is also
@@ -440,36 +440,36 @@ P = \frac{Mweight_{x}}{\sum_{r=1}^{r=n} Mweight_{r}}
 
 [NOTE]
 ====
-The bandwidth enforcement is typically work-conserving, meaning that it allows
-unused bandwidth to be used by requestors enabled to use it even if they have
-consumed their `Rbwb`.
+The bandwidth enforcement is typically work-conserving, allowing unused bandwidth 
+ to be used by requestors that are enabled to use it, even if they have
+consumed their `Rbwb` allotment.
 
 When contending for unused bandwidth, the weighted share is typically 
 computed among the `RCIDs` that are actively generating requests in that
 accounting interval and have a non-zero weight programmed.
 ====
 
-If unique bandwidth allocation is not required for an access-type, then the
-`useShared` parameter may be set to 1 for a `CONFIG_LIMIT` operation. When
-`useShared` is set to 1, the `sharedAT` field specifies the access-type with
-which the bandwidth allocation is shared by the access-type in
+If unique bandwidth allocation is not required for an access-type identifier, then the
+`useShared` parameter can be set to 1 for a `CONFIG_LIMIT` operation. When
+`useShared` is set to 1, the `sharedAT` field specifies the access-type identifer with
+which the bandwidth allocation is shared by the access-type identifier in
 `bc_alloc_ctl.AT`. In this case, the `Rbwb` and `Mweight` fields are ignored,
-and the configurations of the access-type in `sharedAT` are applied. If the
-access-type specified by `sharedAT` does not have unique bandwidth allocation,
+and the configurations of the access-type identifier in `sharedAT` are applied. If the
+access-type identifier specified by `sharedAT` does not have unique bandwidth allocation,
 meaning that it has not been configured with `useShared=0`, then the behavior
 is `UNSPECIFIED`.
 
 The `useShared` and `sharedAT` fields are read-only zero if the bandwidth
-controller does not support bandwidth allocation per access-type.
+controller does not support bandwidth allocation per access-type identifier.
 
 [NOTE]
 ====
-When unique bandwidth allocation for an access-type is not required then one or
-more access-types may be configured with a shared bandwidth allocation. For
-example, consider a bandwidth controller that supports 3 access-types. The
-access-type 0 and 1 of `RCID` 3 are configured with unique bandwidth allocations
-and the access-type 2 is configured to share bandwidth allocation with
-access-type 1. The example configuration is illustrated as follows:
+When unique bandwidth allocation for an access-type identifier is not required, then one or
+more identifiers might be configured with a shared bandwidth allocation. For
+example, consider a bandwidth controller that supports 3 access-type identifers. The
+access-type identifier 0 and 1 of `RCID` 3 are configured with unique bandwidth allocations
+and the access-type identifier 2 is configured to share bandwidth allocation with
+identifier 1. The example configuration is illustrated in the following table:
 
 [width=100%]
 [%header, cols="4,^2,^2,^2,^2"]

--- a/qos_bandwidth.adoc
+++ b/qos_bandwidth.adoc
@@ -149,8 +149,8 @@ listed in <<BC_MON_OP>>.
 | --           | 24-31     | Designated for custom use.
 |===
 
-The `EVT_ID` field uses the `CONFIG_EVENT` operation to program the
-identifier of the event to count in the monitoring counter, selected by `MCID`.
+The `CONFIG_EVENT` operation uses the `EVT_ID` operand to program the identifier of the 
+event to count in the monitoring counter, selected by `MCID`.
 The `AT` field is used to program the access-type to count, and its validity is
 indicated by the `ATV` field. When `ATV` is 0, the counter counts requests with
 all access-types, and the `AT` value is ignored.

--- a/qos_bandwidth.adoc
+++ b/qos_bandwidth.adoc
@@ -87,11 +87,15 @@ allowing all available bandwidth blocks to be reserved for allocation, the
 bandwidth controller can handle such transient inaccuracies.
 ====
 
-If `RPFX` is 1, the controller uses `RCID` in the requests along with `P` least
-significant bits of the `MCID` carried in the request to compute an effective
-`MCID` (<<EMCID>>) to identify the monitoring counter. Valid values of `P` range
-from 0 to 12. If `RPFX` is 0, `P` is set to 0, and the effective `MCID` is the
-same as the `MCID` in the request.
+When the `RCID`-prefixed mode (`RPFX`) is 1, the controller operates in `RPFX` 
+mode. The parameter `P` (prefixed bits) indicates the number of least significant 
+bits of the `MCID` carried in the request that should be prefixed by the RCID. The 
+controller uses `RCID` in the requests along with `P` number of least significant 
+bits of the `MCID` to compute an effective `MCID` (<<EMCID>>). This `MCID` is used 
+to identify the monitoring counter. Legal values of `P` range from 0 to 12. 
+
+If `RPFX` is 0, `P` is set to 0, and the effective `MCID` is the same as the `MCID` 
+in the request.
 
 [[BC_MCTL]]
 === Bandwidth Usage Monitoring Control

--- a/qos_capacity.adoc
+++ b/qos_capacity.adoc
@@ -7,40 +7,40 @@ interface.
 
 The capacity controller allocates capacity in fixed multiples of _capacity
 units_. A group of these _capacity units_ is referred to as a _capacity block_.
-One or more _capacity blocks_ may be allocated to a workload. When a workload
-requests capacity allocation, the capacity is allocated using _capacity units_
+One or more _capacity blocks_ can be allocated to a workload. When a workload
+requests capacity allocation, the capacity is allocated by using _capacity units_
 situated within the _capacity blocks_ assigned to the workload. Capacity blocks
 can also be shared among one or more workloads. Optionally, the capacity
-controller may allow configuration of a limit on the maximum number of _capacity
-units_ that can be occupied in the _capacity blocks_ allocated to a given
+controller might allow configuration of a limit on the maximum number of _capacity
+units_ that can be occupied in the _capacity blocks_ allocated to a specific
 workload.
 
 [NOTE]
 ====
-For example, a cache controller may allocate capacity in multiples of cache
+For example, a cache controller allocates capacity in multiples of cache
 blocks. In this context, a cache block serves as a _capacity unit_, and a group
 of cache blocks forms a _capacity block_. A cache controller supporting capacity
-allocation by ways might define a _capacity block_ to be the cache blocks in one
+allocation might define a _capacity block_ to be the cache blocks in one
 way of the cache.
 ====
 
 The capacity allocation affects the decision regarding which _capacity blocks_
-to use when a new _capacity unit_ is requested by a workload but usually does
+to use when a new _capacity unit_ is requested by a workload, but usually does
 not affect other operations of the controller.
 
 [NOTE]
 ====
 For example, when a request is made to a cache controller, the request involves
 scanning the entire cache to determine if the requested data is present. If the
-data is located, then the request is fulfilled using this data, even if the
+data is located, then the request is fulfilled with this data, even if the
 cache block containing the data was initially allocated for a different
 workload. The data continues to reside in the same cache block. Consequently,
 the cache lookup function remains unaffected by the capacity allocation
-constraints set for the workload initiating the request. Conversely, if the data
+constraints set for the workload that initiated the request. Conversely, if the data
 is not found, a new cache block must be allocated. This allocation is executed
-using the _capacity blocks_ assigned to the workload that made the request.
-Hence, a workload may only trigger evictions within _capacity blocks_ designated
-to it but can access shared data in _capacity blocks_ allocated to other
+by using the _capacity blocks_ assigned to the workload that made the request.
+Hence, a workload might only trigger evictions within _capacity blocks_ designated
+to it, but can access shared data in _capacity blocks_ allocated to other
 workloads.
 ====
 
@@ -159,10 +159,10 @@ The `cc_mon_ctl` register is used to control monitoring of capacity usage by a
 ....
 
 Capacity controllers that support capacity usage monitoring implement a usage
-monitoring counter for each supported `MCID`. The usage monitoring counter may
+monitoring counter for each supported `MCID`. The usage monitoring counter can
 be configured to count a monitoring event. When an event matching the event
-configured for the `MCID` occurs then the monitoring counter is updated. The
-event matching may optionally be filtered by the access-type.
+configured for the `MCID` occurs, then the monitoring counter is updated. The
+event matching might optionally be filtered by the access-type identifier.
 
 The `OP`, `AT`, `ATV`, `MCID`, and `EVT_ID` fields of the register are WARL
 fields.
@@ -190,8 +190,8 @@ in <<CC_MON_OP>>.
 
 The `EVT_ID` field is used to program the identifier of the event to count in
 the monitoring counter selected by `MCID`. The `AT` field (See <<AT_ENC>>) is
-used to program the access-type to count, and its validity is indicated by the
-`ATV` field. When `ATV` is 0, the counter counts requests with all access-types,
+used to program the access-type identifier to count, and its validity is indicated by the
+`ATV` field. When `ATV` is 0, the counter counts requests with all access-type identifiers,
 and the `AT` value is ignored.
 
 <<<
@@ -211,18 +211,18 @@ and the `AT` value is ignored.
 | --           | 128-256   | Designated for custom use.
 |===
 
-When the `EVT_ID` for a `MCID` is programmed with a non-zero and legal value
+When the `EVT_ID` for a `MCID` is programmed with a non-zero and legal value by 
 using the `CONFIG_EVENT` operation, the counter is reset to 0 and starts counting
 matching events for requests with the matching `MCID` and `AT` (if `ATV` is 1).
 However, if the `EVT_ID` is programmed to 0, the counter stops counting.
 
-A controller that does not support monitoring by access-type can hardwire the
+A controller that does not support monitoring by access-type identifier can hardwire the
 `ATV` and the `AT` fields to 0, indicating that the counter counts requests with
-all access-types.
+all access-types identifiers.
 
-When the `cc_mon_ctl` register is written, the controller may need to perform
-several actions that may not complete synchronously with the write. A write to
-the `cc_mon_ctl` sets the read-only `BUSY` bit to 1 indicating the controller
+When the `cc_mon_ctl` register is written, the controller can perform
+several actions that might not complete synchronously with the write. A write to
+the `cc_mon_ctl` sets the read-only `BUSY` bit to 1, indicating the controller
 is performing the requested operation. When the `BUSY` bit reads 0, the operation
 is complete, and the read-only `STATUS` field provides a status value (see
 <<CC_MON_STS>> for  details). Written values to the `BUSY` and the `STATUS`
@@ -249,8 +249,8 @@ the register. The `STATUS` field remains valid until a subsequent write to the
 |===
 
 When the `BUSY` bit is set to 1, the behavior of writes to the `cc_mon_ctl` is
-`UNSPECIFIED`. Some implementations may ignore the second write, while others
-may perform the operation determined by the second write. To ensure proper
+`UNSPECIFIED`. Some implementations ignore the second write, while others
+might perform the operation determined by the second write. To ensure proper
 operation, software must first verify that the `BUSY` bit is 0 before writing
 the `cc_mon_ctl` register.
 
@@ -258,7 +258,7 @@ the `cc_mon_ctl` register.
 === Capacity Usage Monitoring Counter Value
 
 The `cc_mon_ctr_val` is a read-only register that holds a snapshot of the
-counter selected by the `READ_COUNTER` operation. When the controller does not
+counter that is selected by the `READ_COUNTER` operation. When the controller does not
 support capacity usage monitoring, the `cc_mon_ctr_val` register always reads as
 zero.
 
@@ -271,27 +271,27 @@ zero.
 ], config:{lanes: 2, hspace:1024}}
 ....
 
-The counter is valid if the `INV` field is 0. The counter may be marked `INV` if
-the controller, for `UNSPECIFIED` reasons determine the count to be not valid.
-The counters marked `INV` may become valid in future.
+The counter is valid if the `INV` field is 0. The counter is marked `INV` if
+the controller determines the count to be not valid for `UNSPECIFIED` reasons.
+The counters marked `INV` can become valid in future.
 
-The counter shall not decrement below zero. If an event should occur that would
-otherwise result in a negative value, the counter will continue to hold a value
+The counter shall not decrement below zero. If an event occur that would
+otherwise result in a negative value, the counter continues to hold a value
 of 0.
 
 [NOTE]
 ====
-Following a reset of the counter to zero, a capacity de-allocation may attempt
-to drive its value below zero. This scenario may occur when the `MCID` is
+Following a reset of the counter to zero, a capacity de-allocation attempts
+to drive its value below zero. This scenario occurs when the `MCID` is
 reassigned to a new workload, yet the capacity controller continues to hold
-capacity initially allocated by the previous workload. In such cases, the
+capacity that was initially allocated by the previous workload. In such cases, the
 counter shall not decrement below zero and shall remain at zero. After a brief
 period of execution for the new workload post-counter reset, the counter value is
 expected to stabilize to reflect the capacity usage of this new workload.
 
-Some implementations may not store the `MCID` of the request that caused the
+Some implementations might not store the `MCID` of the request that caused the
 capacity to be allocated with every unit of capacity in the controller to
-optimize on the storage overheads. Such controllers may in turn rely on
+optimize for the storage overheads. Such controllers, in turn, rely on
 statistical sampling to report the capacity usage by tagging only a subset
 of the capacity units.
 
@@ -302,14 +302,14 @@ sets. By keeping track of the hits and misses in the monitored sets, it is
 possible to estimate the overall cache occupancy with a high degree of accuracy.
 The size of the subset needed to obtain accurate estimates depends on various
 factors, such as the size of the cache, the cache access patterns, and the
-desired accuracy level. Research cite:[SSAMPLE] has shown that set-sampling can
+desired accuracy level. Research cite:[SSAMPLE] shows that set-sampling can
 provide statistically accurate estimates with a relatively small sample size,
 such as 10% or less, depending on the cache properties and sampling technique
 used.
 
 When the controller has not observed enough samples to provide an accurate
-value in the monitoring counter, it may report the counter as being `INV`
-until more accurate measurements are available. This helps to prevent inaccurate
+value in the monitoring counter, it might report the counter as being `INV`
+until more accurate measurements are available. This state helps to prevent inaccurate
 or misleading data from being used in capacity planning or other decision-making
 processes.
 ====
@@ -318,10 +318,10 @@ processes.
 === Capacity Allocation Control
 
 The `cc_alloc_ctl` register is used to configure allocation of capacity to an
-`RCID` per access-type (`AT`). The `OP`, `RCID` and `AT` fields in this register
-are WARL. If a controller does not support capacity allocation then this
+`RCID` per access type (`AT`). The `OP`, `RCID` and `AT` fields in this register
+are WARL. If a controller does not support capacity allocation, then this
 register is read-only zero. If the controller does not support capacity
-allocation per access-type then the `AT` field is read-only zero.
+allocation per access type, then the `AT` field is read-only zero.
 
 .Capacity Allocation Control Register (`cc_alloc_ctl`)
 [wavedrom, , ]
@@ -345,7 +345,7 @@ targeted _capacity blocks_ are designated in the form of a bitmask in the
 unit_ limit to be defined in the `cc_cunits` register. To execute operations that
 require a capacity block mask and/or a capacity unit limit, software must first
 program the `cc_block_mask` and/or the `cc_cunits` register, followed by
-initiating the operation via the `cc_alloc_ctl` register.
+initiating the operation with the `cc_alloc_ctl` register.
 
 [[CC_ALLOC_OP]]
 .Capacity Allocation Operations (`OP`)
@@ -355,7 +355,7 @@ initiating the operation via the `cc_alloc_ctl` register.
 |Operation     | Encoding ^| Description
 |--            | 0         | Reserved for future standard use.
 |`CONFIG_LIMIT`| 1         | Configure a capacity allocation for requests by
-                             `RCID` and of access-type `AT`. The _capacity
+                             `RCID` and of access type `AT`. The _capacity
                              blocks_ allocation is specified in the
                              `cc_block_mask` register, and a limit on capacity
                              units is specified in the `cc_cunits` register.
@@ -384,37 +384,36 @@ initiating the operation via the `cc_alloc_ctl` register.
 
 Capacity controllers enumerate the allocatable _capacity blocks_ in the `NCBLKS`
 field of the `cc_capabilities` register. The `cc_block_mask` register is
-programmed with a bit-mask where each bit represents a _capacity block_ for the
-operation. A limit on the _capacity unit_, if configuration of such limits is
-supported (i.e., `cc_capabilities.CUNIT=1`), that can be occupied in the
-allocated _capacity blocks_ may be programmed in the `cc_cunits` register. If
-configuration of a limit  on the _capacity units_ is not supported, then the
-controller allows the use of all _capacity units_ in the allocated _capacity
+programmed with a bit-mask value, where each bit represents a _capacity block_ for the
+operation. If configuring _capacity unit_ limits is supported (for example, 
+`cc_capabilities.CUNIT=1`), then the number of allocated capacity blocks can 
+be programmed in the `cc_cunits` register. If configuring limits is not supported, 
+then the controller allows the use of all _capacity units_ in the allocated _capacity
 blocks_. A value of zero programmed into `cc_cunits` indicates that no limits
-should be enforced on _capacity unit_ allocation.
+shall be enforced on _capacity unit_ allocation.
 
-A capacity allocation must be configured for each supported access-type by the
+A capacity allocation must be configured for each supported access type by the
 controller. An implementation that does not support capacity allocation per
-access-type may hardwire the `AT` field to 0 and associate the same capacity
-allocation configuration for requests with all access-types. When capacity
-allocation per access-type is supported, identical limits may be configured for
-two or more access-types if different capacity allocation per access-type is not
-required. If capacity is not allocated for each access-type supported by the
+access type can hardwire the `AT` field to 0 and associate the same capacity
+allocation configuration for requests with all access types. When capacity
+allocation per access type is supported, identical limits can be configured for
+two or more access types, if different capacity allocation per access type is not
+required. If capacity is not allocated for each access type supported by the
 controller, the behavior is `UNSPECIFIED`.
 
 [NOTE]
 ====
 A cache controller that supports capacity allocation indicates the number of
 allocatable _capacity blocks_ in `cc_capabilities.NCBLKS` field. For example,
-let's consider a cache with `NCBLKS=8`. In this example, the `RCID=5` has been
-allocated _capacity blocks_ numbered 0 and 1 for requests with access-type `AT=0`,
-and has been allocated _capacity blocks_ numbered 2 for requests with access-type
-`AT=1`. The `RCID=3` in this example has been allocated _capacity blocks_
-numbered 3 and 4 for both `AT=0` and `AT=1` access-types as separate capacity
-allocation by access-type is not required for this workload. Further in this
+consider a cache with `NCBLKS=8`. In this example, the `RCID=5` is
+allocated _capacity blocks_ numbered 0 and 1 for requests with access type `AT=0`,
+and _capacity blocks_ numbered 2 for requests with access type
+`AT=1`. The `RCID=3` in this example is allocated _capacity blocks_
+numbered 3 and 4 for both `AT=0` and `AT=1` access types as separate capacity
+allocation by access type is not required for this workload. Further in this
 example, the `RCID=6` has been configured with the same _capacity block_
-allocations as `RCID=3`. This implies that they share a common capacity
-allocation in this cache but may have been associated with different `RCID` to
+allocations as `RCID=3`. This configuration implies that they share a common capacity
+allocation in this cache, but might be associated with different `RCID` to
 allow differentiated treatment in another capacity and/or bandwidth controller.
 
 [width=100%]
@@ -440,36 +439,36 @@ blocks, respectively.
 
 <<<
 
-The `FLUSH_RCID` operation may incur a long latency to complete. New requests to
-the controller by the `RCID` being flushed are allowed. Additionally, the
+The `FLUSH_RCID` operation can incur a long latency to complete. New requests to
+the controller by flushing the `RCID` are allowed. Additionally, the
 controller is allowed to deallocate capacity that was allocated after the
 operation was initiated.
 
 [NOTE]
 ====
-For cache controllers, the `FLUSH_RCID` operation may perfom an operation
+For cache controllers, the `FLUSH_RCID` operation perfoms an operation
 similar to that performed by the RISC-V `CBO.FLUSH` instruction on each cache
 block that is part of the allocation configured for the `RCID`.
 
 The `FLUSH_RCID` operation can be used as part of reclaiming a previously
 allocated `RCID` and associating it with a new workload. When such a
-reallocation is performed, the capacity controllers may have capacity allocated
-by the old workload and thus for a short warmup duration the capacity controller
-may be enforcing capacity allocation limits that reflect the usage by the old
-workload. Such warmup durations are typically not statistically significant, but
+reallocation is performed, the capacity controllers might have capacity allocated
+by the old workload and thus for a short warm-up duration, the capacity controller
+might be enforcing capacity allocation limits that reflect the usage by the old
+workload. Such warm-up durations are typically not statistically significant, but
 if that is not desired, then the `FLUSH_RCID` operation can be used to flush and
 evict capacity allocated by the old workload.
 ====
 
-When the `cc_alloc_ctl` register is written, the controller may need to perform
-several actions that may not complete synchronously with the write. A write to
-the `cc_alloc_ctl` sets the read-only `BUSY` bit to 1 indicating the controller
+When the `cc_alloc_ctl` register is written, the controller might perform
+several actions that might not complete synchronously with the write. A write to
+the `cc_alloc_ctl` sets the read-only `BUSY` bit to 1, indicating the controller
 is performing the requested operation. When the `BUSY` bit reads 0, the operation
 is complete, and the read-only `STATUS` field provides a status value
-(<<CC_ALLOC_STS>>) of the requested operation. Values written to the `BUSY` and
+(<<CC_ALLOC_STS>>) of the requested operation. Values that are written to the `BUSY` and
 the `STATUS` fields are always ignored. An implementation that can complete the
-operation synchronously with the write may hardwire the `BUSY` bit to 0. The
-state of the `BUSY` bit, when not hardwired to 0, shall only change in response
+operation synchronously with the write might hardwire the `BUSY` bit to 0. The
+state of the `BUSY` bit, when not hardwired to 0, shall change only in response
 to a write to the register. The `STATUS` field remains valid until a subsequent
 write to the `cc_alloc_ctl` register.
 
@@ -491,7 +490,7 @@ write to the `cc_alloc_ctl` register.
 
 When the `BUSY` bit is set to 1, the behavior of writes to the `cc_alloc_ctl`
 register, `cc_cunits` register, or to the `cc_block_mask` register is
-`UNSPECIFIED`. Some implementations may ignore the second write and others may
+`UNSPECIFIED`. Some implementations might ignore the second write and others might
 perform the operation determined by the second write. To ensure proper operation,
 software must verify that `BUSY` bit  is 0 before writing any of these registers.
 
@@ -499,12 +498,12 @@ software must verify that `BUSY` bit  is 0 before writing any of these registers
 === Capacity Block Mask (`cc_block_mask`)
 
 The `cc_block_mask` is a WARL register. If the controller does not support
-capacity allocation, i.e., `NCBLKS` is 0, then this register is read-only 0.
+capacity allocation, for example, `NCBLKS` is 0, then this register is read-only 0.
 
-The register has `NCBLKS` bits each corresponding to one allocatable
-_capacity block_ in the controller. The width of this register is variable but
+The register has `NCBLKS` bits, each corresponding to one allocatable
+_capacity block_ in the controller. The width of this register is variable, but
 always a multiple of 64 bits. The bitmap width in bits (`BMW`) is determined by
-the equation below. The division operation in this equation is an integer
+the following equation. The division operation in this equation is an integer
 division.
 
 [latexmath#eq-2,reftext="equation ({counter:eqs})"]
@@ -517,49 +516,49 @@ BMW = \lfloor{\frac{NCBLKS + 63}{64}}\rfloor \times 64
 Bits `NCBLKS-1:0` are read-write, and the bits `BMW-1:NCBLKS` are read-only zero.
 
 The process of configuring capacity allocation for an `RCID` and `AT` begins by
-programming the `cc_block_mask` register with a bit-mask that identifies the
+programming the `cc_block_mask` register with a bit-mask value that identifies the
 _capacity blocks_ to be allocated and, if supported, by programming the
-`cc_cunits` register with a limit on the capacity units that may be occupied in
+`cc_cunits` register with a limit on the capacity units that might be occupied in
 those capacity blocks. Next, the `cc_alloc_ctl register` is written to request a
-`CONFIG_LIMIT` operation for the `RCID` and `AT`. Once a capacity allocation
-limit has been established, a request may be allocated capacity in the _capacity
+`CONFIG_LIMIT` operation for the `RCID` and `AT`. After a capacity allocation
+limit is established, a request can be allocated capacity in the _capacity
 blocks_ allocated to the `RCID` and `AT` associated with the request. It is
-important to note that some implementations may require at least one _capacity
-block_ to be allocated using `cc_block_mask` when allocating capacity;
-otherwise, the operation will fail with `STATUS=5`.  Overlapping _capacity block_
+important to note that some implementations might require at least one _capacity
+block_ to be allocated by using `cc_block_mask` when allocating capacity;
+otherwise, the operation fails with `STATUS=5`.  Overlapping _capacity block_
 masks among `RCID` and/or `AT` are allowed to be configured.
 
 [NOTE]
 ====
-A set-associative cache controller that supports capacity allocation by ways
-can advertise `NCBLKS` as the number of ways per set in the cache. To Allocate
+A set-associative cache controller that supports capacity allocation
+can advertise `NCBLKS` as the number of ways per set in the cache. To allocate
 capacity in such a cache for an `RCID` and `AT`, a subset of ways must be
-selected and mask of the selected ways must be programmed in `cc_block_mask` when
-requesting the `CONFIG_LIMIT` operation.
+selected and a mask of the selected ways must be programmed in `cc_block_mask` field when
+the `CONFIG_LIMIT` operation is requested.
 ====
 
 To read the _capacity block_ allocation for an `RCID` and `AT`, the controller
-provides the `READ_LIMIT` operation which can be requested by writing to the
-`cc_alloc_ctl` register. Upon successful completion of the operation, the
+provides the `READ_LIMIT` operation, which can be requested by writing to the
+`cc_alloc_ctl` register. When the operation completes successfully, the
 `cc_block_mask` register holds the configured _capacity block_ allocation.
 
 [[CC_CUNITS]]
 === Capacity Units
 
 The `cc_cunits` register is a read-write WARL register. If the controller does
-not support capacity allocation (i.e., `NCBLKS` is set to 0), this register
+not support capacity allocation (for example, `NCBLKS` is set to 0), this register
 shall be read-only zero.
 
 If the controller does not support configuring limits on _capacity units_ that
-may be occupied in the allocated _capacity blocks_ (i.e.,
-`cc_capabilities.CUNITS=0`) then this register shall be read-only zero. In such
-cases the controller will allow utilization of all available _capacity units_ by
+may be occupied in the allocated _capacity blocks_ (for example,
+`cc_capabilities.CUNITS=0`), then this register shall be read-only zero. In such
+cases, the controller allows the utilization of all available _capacity units_ by
 an `RCID` within the _capacity blocks_ allocated to it.
 
 <<<
 
-If the controller supports configuring limits on _capacity units_ that may be
-occupied in the allocated _capacity blocks_ (i.e., `cc_capabilities.CUNITS=1`)
+If the controller supports configuring limits on _capacity units_ that might be
+occupied in the allocated _capacity blocks_ (for example, `cc_capabilities.CUNITS=1`)
 then this register sets an upper limit on the number of _capacity units_ that
 can be occupied by an `RCID` in the _capacity blocks_ allocated for an `AT`. A
 value of zero specified in the `cc_cunits` register indicates that no limit is
@@ -572,18 +571,18 @@ allocation.
 [NOTE]
 ====
 When multiple `RCID` instances share a _capacity block_ allocation, the
-`cc_cunits` register may be employed to set an upper limit on the number of
+`cc_cunits` register can be employed to set an upper limit on the number of
 _capacity units_ each `RCID` can occupy.
 
 For instance, consider a group of four `RCID` instances configured to share a
 set of _capacity blocks_, representing a total of 100 capacity units. Each
-`RCID` could be configured with a limit of 30 capacity units, ensuring that no
+`RCID` can be configured with a limit of 30 capacity units, ensuring that no
 individual `RCID` exceeds 30% of the total shared _capacity units_.
 
-The capacity controller may enforce these limits through various techniques.
+The capacity controller might enforce these limits through various techniques.
 Examples include:
 
-. Refraining from allocating new capacity units to an `RCID` that has reached
+. Refraining from allocating new capacity units to an `RCID` that reached
   its limit.
 . Evicting previously allocated capacity units when a new allocation is
   required.
@@ -592,12 +591,12 @@ These methods are not exhaustive and can be applied either individually or in
 combination to maintain _capacity unit_ limits.
 
 When the limit on the _capacity units_ is reached or is about to be reached,
-the capacity controller may initiate additional operations. These could include
-throttling certain activities (e.g., prefetches) of the corresponding workload
+the capacity controller can initiate additional operations. These could include
+throttling certain activities (for example, prefetches) of the corresponding workload
 requests.
 ====
 
 To read the _capacity unit_ limit for an `RCID` and `AT`, the controller
-provides the `READ_LIMIT` operation which can be requested by writing to the
-`cc_alloc_ctl` register. Upon successful completion of the operation, the
+provides the `READ_LIMIT` operation that can be requested by writing to the
+`cc_alloc_ctl` register. When the operation completes successfully, the
 `cc_cunits` register holds the configured _capacity unit_ allocation limit.

--- a/qos_capacity.adoc
+++ b/qos_capacity.adoc
@@ -129,11 +129,15 @@ the _capacity blocks_ occupied by an `RCID`.
 
 <<<
 
-If `RPFX` is 1, the controller uses `RCID` in the requests along with `P` least
-significant bits of the `MCID` carried in the request to compute an effective
-`MCID` (<<EMCID>>) to identify the monitoring counter. Legal values of `P` range
-from 0 to 12. If `RPFX` is 0, `P` is set to 0, and the effective `MCID` is the
-same as the `MCID` in the request.
+When the `RCID`-prefixed mode (`RPFX`) is 1, the controller operates in `RPFX` 
+mode. The parameter `P` (prefixed bits) indicates the number of least significant 
+bits of the `MCID` carried in the request that should be prefixed by the RCID. The 
+controller uses `RCID` in the requests along with `P` number of least significant 
+bits of the `MCID` to compute an effective `MCID` (<<EMCID>>). This `MCID` is used 
+to identify the monitoring counter. Legal values of `P` range from 0 to 12. 
+
+If `RPFX` is 0, `P` is set to 0, and the effective `MCID` is the same as the `MCID` 
+in the request.
 
 [[CC_MCTL]]
 === Capacity Usage Monitoring Control

--- a/qos_capacity.adoc
+++ b/qos_capacity.adoc
@@ -20,7 +20,7 @@ workload.
 For example, a cache controller allocates capacity in multiples of cache
 blocks. In this context, a cache block serves as a _capacity unit_, and a group
 of cache blocks forms a _capacity block_. A cache controller supporting capacity
-allocation might define a _capacity block_ to be the cache blocks in one
+allocation _by ways_ might define a _capacity block_ to be the cache blocks in one
 way of the cache.
 ====
 
@@ -386,11 +386,12 @@ Capacity controllers enumerate the allocatable _capacity blocks_ in the `NCBLKS`
 field of the `cc_capabilities` register. The `cc_block_mask` register is
 programmed with a bit-mask value, where each bit represents a _capacity block_ for the
 operation. If configuring _capacity unit_ limits is supported (for example, 
-`cc_capabilities.CUNIT=1`), then the number of allocated capacity blocks can 
-be programmed in the `cc_cunits` register. If configuring limits is not supported, 
-then the controller allows the use of all _capacity units_ in the allocated _capacity
-blocks_. A value of zero programmed into `cc_cunits` indicates that no limits
-shall be enforced on _capacity unit_ allocation.
+`cc_capabilities.CUNIT=1`), then a limit on the _capacity unit_ that can be 
+occupied in the allocated capacity blocks can be programmed in the `cc_cunits` 
+register. If configuring limits is not supported, then the controller allows 
+the use of all _capacity units_ in the allocated _capacity blocks_. A value of 
+zero programmed into `cc_cunits` indicates that no limits shall be enforced on 
+_capacity unit_ allocation.
 
 A capacity allocation must be configured for each supported access type by the
 controller. An implementation that does not support capacity allocation per
@@ -439,10 +440,10 @@ blocks, respectively.
 
 <<<
 
-The `FLUSH_RCID` operation can incur a long latency to complete. New requests to
-the controller by flushing the `RCID` are allowed. Additionally, the
-controller is allowed to deallocate capacity that was allocated after the
-operation was initiated.
+The `FLUSH_RCID` operation can incur a long latency to complete. However, the 
+`RCID` can submit new requests to the controller while it is being flushed. 
+Additionally, the controller is allowed to deallocate capacity that was allocated 
+after the operation was initiated.
 
 [NOTE]
 ====
@@ -530,8 +531,8 @@ masks among `RCID` and/or `AT` are allowed to be configured.
 
 [NOTE]
 ====
-A set-associative cache controller that supports capacity allocation
-can advertise `NCBLKS` as the number of ways per set in the cache. To allocate
+A multiway set-associative cache controller that supports capacity allocation _by 
+ways_ can advertise `NCBLKS` as the number of ways per set in the cache. To allocate
 capacity in such a cache for an `RCID` and `AT`, a subset of ways must be
 selected and a mask of the selected ways must be programmed in `cc_block_mask` field when
 the `CONFIG_LIMIT` operation is requested.

--- a/qos_guidelines.adoc
+++ b/qos_guidelines.adoc
@@ -3,24 +3,24 @@
 
 === Sizing QoS Identifiers
 
-In a typical implementation the number of `RCID` bits implemented (e.g., to
-support 10s of `RCIDs`) may be smaller than the number of `MCID` bits
-implemented (e.g., to support 100s of `MCIDs`). 
+In a typical implementation, the number of `RCID` bits implemented (for example, to
+support 10s of `RCIDs`) might be smaller than the number of `MCID` bits
+implemented (for example, to support 100s of `MCIDs`). 
 
 It is a typical usage to associate a group of applications/VMs with a common
 `RCID` and thus sharing a common pool of resource allocations. The resource
 allocations for the `RCID` is established to meet the SLA objectives of all
 members of the group. If SLA objectives of one or more members of the group
-stop being met, the resource usage of one or more members of the group may be
+stop being met, the resource usage of one or more members of the group might be
 monitored by associating them with a unique `MCID` and this iterative analysis
 process used to determine the optimal strategy - increasing resources allocated
 to the `RCID`, moving some members to a different `RCID`, migrating some members
-away to another machine, etc. - for restoring the SLA. Having a sufficiently
+away to another machine, and so on. - for restoring the SLA. Having a sufficiently
 large pool of `MCID` speeds up this analysis.
 
 [NOTE]
 ====
-To support maximal flexibility in allocation of QoS IDs to workloads it is
+To support maximal flexibility in allocation of QoS IDs to workloads, it is
 recommended for all resource controllers in the system to support an identical
 number of `RCID` and `MCID`.
 ====
@@ -45,7 +45,7 @@ To differential requests to shared resources originating from TEEs from
 non-TEEs a confidential-access indicator accompanies requests made to the shared
 resources. 
 
-The resource controller may then use the confidential-access indicator along
+The resource controller might then use the confidential-access indicator along
 with the QoS identifiers that accompany the request to determine the resource
 allocations and the monitoring counters to use.
 
@@ -56,36 +56,36 @@ Supporting confidential computing thus requires following additional capabilitie
 
 ==== Secure register programming interface
 
-To support secure execution a CBQRI capable controller may provide a second
+To support secure execution, a CBQRI capable controller might provide a second
 register programming interface that is used to establish resource allocations
 and resource usage monitoring for secure execution. The secure register 
-programming interface has the same register layout and behavior defined as
+programming interface includes the same register layout and behavior defined as
 specified in this specification.
 
 Access to the secure register programming interfaces should be restricted to the
-secure execution supervisor (e.g., secure M-mode) using the PMP.
+secure execution supervisor (for example, secure M-mode) by using the PMP.
 
 The resource controllers that support confidential computing thus support two
 set of resource allocation configurations - confidential and non-confidential -
 for each `RCID` and `AT`. The confidential resource allocation configurations
-may on only be accessed through the secure register programming interface.
+can be accessed only through the secure register programming interface.
 
 The resource controllers that support confidential computing thus support two
 set of resource usage monitoring events and counters - confidential and
 non-confidential - for each `MCID` and `AT`. The confidential monitoring events
-and counters may on only be accessed through the secure register programming
+and counters can be accessed only through the secure register programming
 interface.
 
-An implementation may restrict number of `RCID` and `MCID` that may be used for
+An implementation can restrict number of `RCID` and `MCID` that might be used for
 confidential computing and thereby implement a smaller number of entries in the
-configuration tables that may be programmed through the secure register
+configuration tables that can be programmed through the secure register
 programming interface.
 
 [NOTE]
 ====
-To support maximal flexibility in allocation of QoS IDs to TEEs it is
+To support maximal flexibility in allocation of QoS IDs to TEEs, it is
 recommended for all resource controllers in the system to support an identical
-number of `RCID` and `MCID` that may be associated with TEEs.
+number of `RCID` and `MCID` that might be associated with TEEs.
 ====
 
 ==== Confidential-access indication
@@ -96,33 +96,33 @@ and `AT`.
 
 The `C` bit associated with the request indicates whether the access is to a
 confidential resources (`C=1`) or to a non-confidential resource. For memory
-controllers and caches, for example, the `C` bit may be determined as a property
+controllers and caches, for example, the `C` bit can be determined as a property
 of the memory region accessed. 
 
-Execution in a TEE may generate requests associated with both settings of `C`
+Execution in a TEE generates requests associated with both settings of `C`
 bit. For example, when a TEE accesses its confidential memory the `C` bit
 associated with such requests will be 1 and when the TEE accesses
-non-confidential memory (e.g., memory buffers used by the TEE for communication
-with agents outside the TEE) then the `C` bit associated the request will be 0.
+non-confidential memory (for example, memory buffers used by the TEE for communication
+with agents outside the TEE), then the `C` bit associated the request will be 0.
 
-Execution outside of a TEE may only be requests with `C=0` as access to
+Execution outside of a TEE might only be requests with `C=0`, as access to
 confidential resources is restricted to TEEs.
 
 For requests with `C=1`, resource controllers use the confidential resource
-allocation configurations that were established using the secure register
+allocation configurations that were established by using the secure register
 programming interface for the associated `RCID` and `AT`. For requests with
-`C=0`, resource controllers use the configurations that were established using
+`C=0`, resource controllers use the configurations that were established by using
 the non-secure register programming interface.
 
 For requests with `C=1`, the monitoring events programmed through the secure
 register programming events for the associated `MCID` and `AT` are triggered and
-are counted in monitoring counters that may only be accessed using the secure
+are counted in monitoring counters that can be accessed only by using the secure
 register programming interface.
 
 [NOTE]
 ====
-The confidential-access indicator may be determined at the originator of the
-request and thus be carried along with the request or may be determined at the
+The confidential-access indicator can be determined at the originator of the
+request and thus be carried along with the request or can be determined at the
 resource controller itself based on the properties of the address space
 accessed.
 ====
@@ -133,72 +133,71 @@ accessed.
 
 Typically, the contents of the `sqoscfg` CSR is updated with a new `RCID`
 and/or `MCID` by the HS/S-mode scheduler if the `RCID` and/or `MCID` of the
-new process/VM is not same as that of the old process/VM.
+new process/VM is not same as that of the previous process/VM.
 
-Usually for virtual machines the resource allocations are configured by the
-hypervisor. Usually the Guest OS in a virtual machine does not participate in
+Usually, for virtual machines, the resource allocations are configured by the
+hypervisor. Usually, the Guest OS in a virtual machine does not participate in
 the QoS flows as the Guest OS does not know the physical capabilities of the
 platform or the resource allocations for other virtual machines in the system.
-If a use case requires it, a hypervisor may virtualize the QoS capability to a
-VM by virtualizing the memory-mapped CBQRI register interface and using the
+If a use case requires it, a hypervisor can virtualize the QoS capability to a
+VM by virtualizing the memory-mapped CBQRI register interface and by using the
 virtual-instruction exception on access to `sqoscfg` CSR.
 
 [NOTE]
 ====
 If the use of directly selecting among a set of `RCID` and/or `MCID` by a VM
-becomes more prevalent and the overhead of virtualizing the `sqoscfg` CSR using
-the virtual instruction exception is not acceptable then a future extension may
+becomes more prevalent and the overhead of virtualizing the `sqoscfg` CSR by using
+the virtual instruction exception is not acceptable, then a future extension might
 be introduced where the `RCID`/`MCID` attempted to be written by VS mode are
 used as a selector for a set of `RCID`/`MCID` that the hypervisor configures in
 a set of HS mode CSRs.
 ====
 
-A Hypervisor may cause a context switch from one virtual machine to another. The
-context switch usually involves saving the context associated with the VM being
-switched away from and restoring the context of the VM being switched to. Such
-context switch may be invoked in response to an explicit call from the VM (i.e,
-as a function of an `ECALL` invocation) or may be done asynchronously (e.g., in
-response to a timer interrupt). In such cases the hypervisor may want to execute
-with the `sqoscfg` configurations of the VM being switched away from such that
-the execution is attributed to the VM being switched from and then prior to
-executing the context switch code associated with restoring the new VMs context
-first switch to the `sqoscfg` appropriate for the new VM being switched to such
-that all of that execution is attributed to the new VM. Further in this context
-switch process, if the hypervisor intends some of the execution to be attributed
-to neither the outgoing VM nor the incoming VM, then the hypervisor may switch
-to a new configuration that is different from the configuration of either of the
-VMs for the duration of such execution. QoS capabilities are statistical in
-nature and the small duration, such as the few instructions in the hypervisor
-trap handler entrypoint, for which the HS-mode may execute with the `RCID`/
-`MCID` established for lower privilege mode operation may not be statistically
-significant.
+A Hypervisor might cause a context switch from one virtual machine to another. The
+context switch usually involves saving the context associated with the VM that is being
+switched away from and restoring the context of the VM that is being switched to. Such
+context switch might be invoked in response to an explicit call from the VM (for example,
+as a function of an `ECALL` invocation) or might be done asynchronously (for example, in
+response to a timer interrupt). In such cases, the hypervisor might want to execute
+with the `sqoscfg` configurations of the VM that is being switched away from so that
+the execution is attributed to that VM. Then, before executing the context switch code
+associated with restoring the new VMs context, first switch to the `sqoscfg` tht is 
+appropriate for the new VM that is being switched to so that all of that execution 
+is attributed to the new VM. Further in this context switch process, if the hypervisor 
+intends some of the execution to be attributed to neither the outgoing VM nor the 
+incoming VM, then the hypervisor can switch to a new configuration that is different from 
+the configuration of either of the VMs for the duration of such execution. QoS 
+capabilities are statistical in nature and the small duration, such as the few 
+instructions in the hypervisor trap handler entrypoint for which the HS-mode can 
+execute with the `RCID`/`MCID` values established for lower privilege mode operation,
+might not be statistically significant.
 
 === QoS Identifiers for supervisor and machine mode
 
-The `RCID` and `MCID` configured in `sqoscfg` also apply to execution in
-S/HS-mode but is typically not an issue. Usually, S/HS-mode execution occurs to
+The `RCID` and `MCID` values configured in `sqoscfg` also apply to execution in
+S/HS-mode, but is typically not an issue. Usually, S/HS-mode execution occurs to
 provide services, such as through the SBI, to software executing at lower
-privilege. Since the S/HS-mode invocation was to provide a service for the
-lower privilege mode, the S/HS-mode software may not modify the `sqoscfg` CSR.
+privilege. Because the S/HS-mode invocation was to provide a service for the
+lower privilege mode, the S/HS-mode software cannot modify the `sqoscfg` CSR.
 
 If a use case requires use of separate `RCID` and/or `MCID` for software
-execution in S/HS-mode, then the S/HS-mode SW may update the `sqoscfg` CSR and
-restore it prior to returning to the lower privilege mode execution.
+execution in S/HS-mode, then the S/HS-mode SW might update the `sqoscfg` CSR and
+restore it before returning to the lower privilege mode execution.
 
 The `RCID` and `MCID` configured in `sqoscfg` also apply to execution in M-mode
 but is typically not an issue. Usually, M-mode execution occurs to provide
 services, such as through the SBI interface, to software executing at lower
-privilege. Since the M-mode invocation was to provide a service for the lower
-privilege mode, the M-mode software may not modify the `sqoscfg` CSR. If a use
-case requires use of a separate `RCID` and/or `MCID` for software execution in
-M-mode, then the M-mode SW may update the `sqoscfg` CSR and restore it prior to
+privilege. Because the M-mode invocation provides a service for the lower
+privilege mode, the M-mode software might not modify the `sqoscfg` CSR. If a use
+case requires the use of a separate `RCID` and/or `MCID` for software execution in
+M-mode, then the M-mode SW can update the `sqoscfg` CSR and restore it before
 returning to lower privilege mode execution.
 
 === Secure register programming interface
 
 Security monitors such as the TEE security monitor must protect the secure
 register programming interface from read or write access by non-secure entities.
-Methods such as PMPs, page tables, etc. may be employed to implementation such
+Methods such as PMPs, page tables, and so on can be employed to implementation such
 protection mechanisms.
 
 When multiple security domains exists the control of the secure register

--- a/qos_guidelines.adoc
+++ b/qos_guidelines.adoc
@@ -161,7 +161,7 @@ as a function of an `ECALL` invocation) or might be done asynchronously (for exa
 response to a timer interrupt). In such cases, the hypervisor might want to execute
 with the `sqoscfg` configurations of the VM that is being switched away from so that
 the execution is attributed to that VM. Then, before executing the context switch code
-associated with restoring the new VMs context, first switch to the `sqoscfg` tht is 
+associated with restoring the new VMs context, first switch to the `sqoscfg` that is 
 appropriate for the new VM that is being switched to so that all of that execution 
 is attributed to the new VM. Further in this context switch process, if the hypervisor 
 intends some of the execution to be attributed to neither the outgoing VM nor the 
@@ -178,7 +178,7 @@ The `RCID` and `MCID` values configured in `sqoscfg` also apply to execution in
 S/HS-mode, but is typically not an issue. Usually, S/HS-mode execution occurs to
 provide services, such as through the SBI, to software executing at lower
 privilege. Because the S/HS-mode invocation was to provide a service for the
-lower privilege mode, the S/HS-mode software cannot modify the `sqoscfg` CSR.
+lower privilege mode, the S/HS-mode software might not modify the `sqoscfg` CSR.
 
 If a use case requires use of separate `RCID` and/or `MCID` for software
 execution in S/HS-mode, then the S/HS-mode SW might update the `sqoscfg` CSR and

--- a/qos_hw_guidelines.adoc
+++ b/qos_hw_guidelines.adoc
@@ -4,19 +4,19 @@
 [[QOS_SIZING]]
 === Sizing QoS Identifiers
 
-In a typical implementation the number of `RCID` bits implemented (e.g., to
-support 10s of `RCIDs`) may be smaller than the number of `MCID` bits
-implemented (e.g., to support 100s of `MCIDs`). 
+In a typical implementation, the number of `RCID` bits implemented (for example, to
+support 10s of `RCIDs`) might be smaller than the number of `MCID` bits
+implemented (for example, to support 100s of `MCIDs`). 
 
 It is a typical usage to associate a group of applications/VMs with a common
 `RCID` and thus sharing a common pool of resource allocations. The resource
 allocations for the `RCID` is established to meet the SLA objectives of all
 members of the group. If SLA objectives of one or more members of the group
-stop being met, the resource usage of one or more members of the group may be
+stop being met, the resource usage of one or more members of the group might be
 monitored by associating them with a unique `MCID` and this iterative analysis
 process used to determine the optimal strategy - increasing resources allocated
 to the `RCID`, moving some members to a different `RCID`, migrating some members
-away to another machine, etc. - for restoring the SLA. Having a sufficiently
+away to another machine, and so on - for restoring the SLA. Having a sufficiently
 large pool of `MCID` speeds up this analysis.
 
 [NOTE]

--- a/qos_identifiers.adoc
+++ b/qos_identifiers.adoc
@@ -18,19 +18,19 @@ configure counters identified by the `MCID` to count events in the resource
 controllers that control accesses to such shared resources.
 
 <<QOS_SIZING>> discusses guidelines for sizing the QoS IDs and the need for
-differentiated IDs for monitoring. All supported `RCID` and `MCID` may be
+differentiated IDs for monitoring. All supported `RCID` and `MCID` can be
 actively used in the system at any instance.
 
 [[EMCID]]
 === Associating `RCID` and `MCID` with requests
 
 The `RCID` in the request is used by the resource controllers to determine the
-resource allocations (e.g., cache occupancy limits, memory bandwidth limits,
-etc.) to enforce.
+resource allocations (for example, cache occupancy limits, memory bandwidth limits,
+and so on) to enforce.
 
 The `MCID` in the request is used by the resource controllers to identify the ID
-of a counter to monitor resource usage (e.g., cache occupancy, memory bandwidth,
-etc.). Two modes of operation are supported by CBQRI. In the direct mode, the
+of a counter to monitor resource usage (for example, cache occupancy, memory bandwidth,
+and so on). Two modes of operation are supported by CBQRI. In the direct mode, the
 `MCID` carried with the request is directly used by the controller to identify
 the counter and is the effective `MCID`. In the RCID-prefixed mode, the
 controller identifies the counter for monitoring using an effective `MCID`
@@ -53,38 +53,38 @@ of `mstateen0` controls access to `srmcfg` from privilege modes less than M.
 
 A RISC-V IOMMU cite:[IOMMU] extension to support configuring QoS identifiers is
 specified in <<QOS_IOMMU>>. If the system supports an IOMMU with this extension,
-the IOMMU may be configured with the `RCID` and `MCID` to associate with requests
+the IOMMU can be configured with the `RCID` and `MCID` to associate with requests
 from devices and from the IOMMU itself.
 
 If the system does not support an IOMMU with this extension, then the
 association of `RCID` and `MCID` with requests from devices becomes
-implementation-defined. Such methods may include, but are not limited to, one of
-the following:
+implementation-defined. Such methods can include, but are not limited to, one of
+the following examples:
 
-* Devices may be configured with an `RCID` and `MCID` for requests originating
+* Devices can be configured with an `RCID` and `MCID` for requests originating
   from the device, provided the device implementation and the bus protocol used
   by the device support such capabilities. The method to configure the QoS
   identifiers into devices remains `UNSPECIFIED`.
 
 * Where the device does not natively support being configured with an `RCID`
-  and `MCID`, the implementation may provide a shim at the device interface. This
-  shim may be configured with the `RCID` and `MCID` to associate with requests
+  and `MCID`, the implementation might provide a shim at the device interface. This
+  shim can be configured with the `RCID` and `MCID` to associate with requests
   originating from the device. The method to configure such QoS identifiers into
   a shim is `UNSPECIFIED`.
 
-=== Access-type (`AT`)
+=== Access type (`AT`)
 
 In some usages, in addition to providing differentiated service among workloads,
 the ability to differentiate between resource usage for accesses made by the
-same workload may be required. For example, the capacity allocated in a shared
-cache for code storage may be differentiated from the capacity allocated for
+same workload might be required. For example, the capacity allocated in a shared
+cache for code storage might be differentiated from the capacity allocated for
 data storage and thereby avoid code from being evicted from such shared cache
 due to a data access.
 
-When differentiation based on access type (e.g. code vs. data) is supported the
+When differentiation based on access type (for example, code vs. data) is supported the
 requests also carry an access-type (`AT`) indicator. The resource controllers
-may be configured with separate capacity and/or bandwidth allocations for each
-supported access-type. CBQRI defines a 3-bit `AT` field, encoded as specified in
+can be configured with separate capacity and/or bandwidth allocations for each
+supported access type. CBQRI defines a 3-bit `AT` field, encoded as specified in
 <<AT_ENC>>, in the register interface to configure differentiated resource
 allocation and monitoring for each `AT`.
 

--- a/qos_intro.adoc
+++ b/qos_intro.adoc
@@ -110,7 +110,7 @@ implement the `REV8` byte-reversal instruction defined by the Zbb extension. If
 sequence of instructions.
 ====
 
-A controller can support a subset of capabilities tht are defined by CBQRI. When a 
+A controller can support a subset of capabilities that are defined by CBQRI. When a 
 capability is not supported, the registers and/or fields used to configure and/or
 control such capabilities are hardwired to `0`. Each controller supports a
 capabilities register to enumerate the supported capabilities.

--- a/qos_intro.adoc
+++ b/qos_intro.adoc
@@ -3,79 +3,79 @@
 
 Quality of Service (QoS) is defined as the minimal end-to-end performance that
 is guaranteed in advance by a service level agreement (SLA) to a workload. A
-workload may be a single application, a group of applications, a virtual machine,
-a group of virtual machines, or a combination of those. The performance may
-be measured in the form of metrics such as instructions per cycle (IPC), latency
+workload can be a single application, a group of applications, a virtual machine,
+a group of virtual machines, or a combination of those. The performance is measured 
+in the form of metrics such as instructions per cycle (IPC), latency
 of servicing work, etc.
 
 Various factors such as the available cache capacity, memory bandwidth,
-interconnect bandwidth, CPU cycles, system memory, etc. affect the performance
-in a computing system that runs multiple workloads concurrently. Furthermore,
-when there is arbitration for shared resources, the prioritization of the
-workloads' requests against other competing requests may also affect the
-performance of the workload. Such interference due to resource sharing may lead
+interconnect bandwidth, CPU cycles, system memory, and so on affect the performance
+of a computing system that runs multiple workloads concurrently. Furthermore,
+during arbitration for shared resources, the prioritization of the
+workloads' requests against other competing requests might also affect the
+performance of the workload. Such interference due to resource sharing can lead
 to unpredictable workload performance cite:[PTCAMP].
 
 When multiple workloads are running concurrently on modern processors with large
 core counts, multiple cache hierarchies, and multiple memory controllers, the
-performance of a workload becomes less deterministic or even non-deterministic.
-This is because the performance depends on the behavior of all the other
-workloads in the machine that contend for the shared resources, leading to
+performance of a workload can become less deterministic or even non-deterministic.
+This situation occurs because the worload performance depends on the behavior of the 
+other workloads in the machine that contend for the shared resources, whcih can lead to
 interference. In many deployment scenarios, such as public cloud servers, the
-workload owner may not be in control of the type and placement of other
+workload owner might not be in control of the type and placement of other
 workloads in the platform.
 
 System software can control some of these resources available to the workload,
 such as the number of hardware threads made available for execution, the amount
-of system memory allocated to the workload, the number of CPU cycles provided
-for execution, etc. 
+of system memory allocated to the workload, and the number of CPU cycles provided
+for execution. 
 
 System software needs additional tools to control interference to a workload
-and thereby reduce the variability in performance experienced by one workload
+and thereby reduce the variability in the performance that is experienced by one workload
 due to other workloads' cache capacity usage, memory bandwidth usage,
-interconnect bandwidth usage, etc. through a resource allocation capability.
+interconnect bandwidth usage, and so on through a resource allocation capability.
 The resource allocation capability enables system software to reserve capacity
 and/or bandwidth to meet the performance goals of the workload. Such controls
-enable improving the utilization of the system by collocating workloads while
+can improve the utilization of the system by co-locating workloads while
 minimizing the interference caused by one workload to another cite:[HERACLES].
 
-Effective use of the resource allocation capability requires hardware to provide
+Effective use of the resource allocation capability requires the hardware to provide
 a resource monitoring capability by which the resource requirements of a
 workload needed to meet a certain performance goal can be characterized. A
-typical use model involves profiling the resource usage of the workload using
+typical use model involves profiling the resource usage of the workload by using
 the resource monitoring capability and to establish resource allocations for the
-workload using the resource allocation capability.
+workload by using the resource allocation capability.
 
-The allocation may be in the form of capacity or bandwidth, depending on the type
+The allocation might be in the form of capacity or bandwidth, depending on the type
 of resource. For caches, TLBs, and directories, the resource allocation is in
 the form of storage capacity. For interconnects and memory controllers, the
 resource allocation is in the form of bandwidth.
 
 Workloads generate different types of accesses to shared resources. For example,
-some of the requests may be for accessing instructions and others may be to
-access data operated on by the workload. Certain data accesses may not have
-temporal locality whereas others may have a high probability of reuse. In some
-cases it is desirable to provide differentiated treatment to each type of access
-by providing unique resource allocation to each access type.
+some of the requests might be for accessing instructions and other requests might be 
+to access data that is operated on by the workload. Certain data accesses might not have
+temporal locality, whereas others can have a high probability of reuse. In some
+cases, you can provide differentiated treatment to each type of access by providing 
+unique resource allocation to each access type.
 
 RISC-V Capacity and Bandwidth Controller QoS Register Interface (CBQRI) 
-specification specifies:
+specification specifies the following identifiers and interfaces:
 
 . QoS identifiers to identify workloads that originate requests to the shared
   resources. These QoS identifiers include an identifier for resource allocation
   configurations and an identifier for the monitoring counters used to monitor
-  resource usage. These identifiers accompany each request made by the workload
-  to the shared resource. <<QOS_ID>> specifies the mechanism to associate the
-  identifiers with workloads.
+  resource usage. These identifiers accompany each request that is made by the 
+  workload to the shared resource. <<QOS_ID>> specifies the mechanism to associate 
+  the identifiers with workloads.
 . Access-type identifiers to accompany request to access a shared resource to
-  allow differentiated treatment of each access-type (e.g., code vs. data,
-  etc.). The access-types are defined in <<QOS_ID>>.
-. Register interface for capacity allocation in controllers such as shared
-  caches, directories, etc. The capacity allocation register interface is
+  allow differentiated treatment of each access-type (for example, code vs. data,). 
+  The access-types are defined in <<QOS_ID>>.
+. Register interface for capacity allocation in controllers, such as shared
+  caches, directories, and so on. The capacity allocation register interface is
   specified in <<CC_QOS>>.
 . Register interface for capacity usage monitoring. The capacity usage
   monitoring register interface is specified in <<CC_QOS>>.
-. Register interface for bandwidth allocation in controllers such as
+. Register interface for bandwidth allocation in controllers, such as
   interconnect and memory controllers. The bandwidth allocation register
   interface is specified in <<BC_QOS>>.
 . Register interface for bandwidth usage monitoring. The bandwidth
@@ -84,39 +84,38 @@ specification specifies:
 The capacity and bandwidth controller register interfaces for resource
 allocation and usage monitoring are defined as memory-mapped registers. Each
 controller that supports CBQRI provides a set of registers that are
-memory-mapped starting at an 8-byte aligned physical address. The memory-mapped
-registers may be accessed using naturally aligned 4-byte or 8-byte memory
+memory-mapped, starting at an 8-byte aligned physical address. The memory-mapped
+registers can be accessed by using naturally aligned 4-byte or 8-byte memory
 accesses. The controller behavior for register accesses where the address is not
 aligned to the size of the access, or if the access spans multiple registers, or
 if the size of the access is not 4 bytes or 8 bytes, is `UNSPECIFIED`. A 4-byte
 access to a register must be single-copy atomic. Whether an 8-byte access to a
-CBQRI register is single-copy atomic is `UNSPECIFIED`, and such an access may
+CBQRI register is single-copy atomic is considered `UNSPECIFIED`. This type of access can
 appear, internally to the CBQRI implementation, as if two separate 4-byte
-accesses were performed.
+accesses are performed.
 
 [NOTE]
 ====
-The CBQRI registers are defined in such a way that software can perform two
-individual 4 byte accesses, or hardware can perform two independent 4 byte
-transactions resulting from an 8 byte access, to the high and low halves of the
-register as long as the register semantics, with regards to side-effects, are
-respected between the two software accesses, or two hardware transactions,
+The CBQRI registers are defined so that the software can perform two
+individual 4 byte accesses or the hardware can perform two independent 4-byte
+transactions to the high and low halves of the register, as long as the register 
+semantics are respected between the two software accesses or two hardware transactions,
 respectively.
 ====
 
-The controller registers have little-endian byte order (even if all harts are
+The controller registers use little-endian byte order (even if all harts are
 big-endian-only).
 
 [NOTE]
 ====
-Big-endian-configured harts that make use of the register interface may
+Big-endian-configured harts that make use of the register interface might
 implement the `REV8` byte-reversal instruction defined by the Zbb extension. If
-`REV8` is not implemented, then endianness conversion may be implemented using a
+`REV8` is not implemented, then endianness conversion might be implemented by using a
 sequence of instructions.
 ====
 
-A controller may support a subset of capabilities defined by CBQRI. When a 
-capability is not supported the registers and/or fields used to configure and/or
-control such capabilities are hardwired to 0. Each controller supports a
+A controller can support a subset of capabilities tht are defined by CBQRI. When a 
+capability is not supported, the registers and/or fields used to configure and/or
+control such capabilities are hardwired to `0`. Each controller supports a
 capabilities register to enumerate the supported capabilities.
 

--- a/qos_intro.adoc
+++ b/qos_intro.adoc
@@ -96,11 +96,7 @@ accesses are performed.
 
 [NOTE]
 ====
-The CBQRI registers are defined so that the software can perform two
-individual 4 byte accesses or the hardware can perform two independent 4-byte
-transactions to the high and low halves of the register, as long as the register 
-semantics are respected between the two software accesses or two hardware transactions,
-respectively.
+The CBQRI registers are defined so that software can perform two individual 4 byte accesses, or hardware can perform two independent 4 byte transactions resulting from an 8 byte access, to the high and low halves of the register as long as the register semantics, with regards to side-effects, are respected between the two software accesses, or two hardware transactions, respectively.
 ====
 
 The controller registers use little-endian byte order (even if all harts are

--- a/qos_intro.adoc
+++ b/qos_intro.adoc
@@ -20,7 +20,7 @@ When multiple workloads are running concurrently on modern processors with large
 core counts, multiple cache hierarchies, and multiple memory controllers, the
 performance of a workload can become less deterministic or even non-deterministic.
 This situation occurs because the worload performance depends on the behavior of the 
-other workloads in the machine that contend for the shared resources, whcih can lead to
+other workloads in the machine that contend for the shared resources, which can lead to
 interference. In many deployment scenarios, such as public cloud servers, the
 workload owner might not be in control of the type and placement of other
 workloads in the platform.

--- a/qos_iommu.adoc
+++ b/qos_iommu.adoc
@@ -1,9 +1,10 @@
 [[QOS_IOMMU]]
 == IOMMU Extension for QoS ID
 
-A method to associate QoS IDs with requests to access resources by the IOMMU, as
-well as with devices governed by it, is required for effective monitoring and
-allocation. This section specifies a RISC-V IOMMU cite:[IOMMU] extension to:
+A method to associate QoS IDs with requests to access resources by the Input-Output 
+Memory Management Unit (IOMMU), as well as with devices governed by it, is required 
+for effective monitoring and allocation. This section specifies a RISC-V I
+OMMU cite:[IOMMU] extension for the following goals:
 
 * Configure and associate QoS IDs for device-originated requests.
 * Configure and associate QoS IDs for IOMMU-originated requests.
@@ -16,9 +17,8 @@ by any RISC-V application processor hart in the system.
 
 The specified memory-mapped register layout defines a new IOMMU register named
 `iommu_qosid`. This register is used to configure the Quality of Service (QoS)
-IDs associated with IOMMU-originated requests. The register has a size of 4
-bytes and is located at an offset of 624 from the beginning of the memory-mapped
-region.
+IDs associated with IOMMU-originated requests. The register is 4 bytes in size
+and is located at an offset of 624 from the beginning of the memory-mapped region.
 
 .IOMMU Memory-mapped Register Layout
 [width=100%]
@@ -36,11 +36,11 @@ If the reset value for `ddtp.iommu_mode` field is `Bare`, then the
 
 [NOTE]
 ====
-At reset, it is required that the `RCID` field of `iommu_qosid` be set to 0 if
+At reset, it is required that the `RCID` field of `iommu_qosid` is set to 0 if
 the IOMMU is in `Bare` mode, as typically the resource controllers in the
 SoC default to a reset behavior of associating all capacity or bandwidth to the
 `RCID` value of 0. When the reset value of the `ddtp.iommu_mode` is not `Bare`,
-the `iommu_qosid` register should be initialized by software prior to changing
+the `iommu_qosid` register should be initialized by software before changing
 the mode to allow DMA.
 ====
 
@@ -170,13 +170,13 @@ this case, the IOMMU should stop and report "DDT entry misconfigured" (cause =
 
 === IOMMU ATC Capacity Allocation and Monitoring
 
-Some IOMMUs may support capacity allocation and usage monitoring in the IOMMU
+Some IOMMUs might support capacity allocation and usage monitoring in the IOMMU
 address translation cache (IOATC) by implementing the capacity controller
 register interface.
 
-Additionally, some IOMMUs may support multiple IOATCs, each potentially having
+Additionally, some IOMMUs might support multiple IOATCs, each potentially having
 different capacities. In scenarios where multiple IOATCs are implemented, such
-as an IOATC for each supported page size, the IOMMU may implement a
+as an IOATC for each supported page size, the IOMMU can implement a
 capacity controller register interface for each IOATC to facilitate individual
 capacity allocation.
 

--- a/qos_sw_guidelines.adoc
+++ b/qos_sw_guidelines.adoc
@@ -8,38 +8,38 @@ be reported to operating systems using methods such as ACPI and/or device tree.
 For each capacity and bandwidth controller, the following information should be
 reported using these methods:
 
-* Type of controller (e.g, cache, interconnect, memory, etc.)
+* Type of controller (for example, cache, interconnect, memory, and so on)
 * Location of the register programming interface for the controller
 * Placement and topology describing the hart and IO bridges that share the
   resources controlled by the controller
 * The number of QoS identifiers supported by the controller
-* For memory bandwidth controllers, the controlled memory regions. These may be
-  described in the form of NUMA domains or proximity domains
+* For memory bandwidth controllers, the controlled memory regions. These regions might
+  be described in the form of NUMA domains or proximity domains.
 * If a controller is part of a set of controllers that collectively control a
   shared resource such as memory bandwidth of a memory region, then information
-  to identify all members of the set should be reported
+  to identify all members of the set should be reported.
 * Constraints imposed by the controllers, such as the minimum number of capacity
-  or bandwidth blocks per RCID
+  or bandwidth blocks per RCID.
 
 === Context Switching QoS Identifiers
 
 Typically, the contents of the `srmcfg` CSR are updated with a new `RCID`
 and/or `MCID` by the HS/S-mode scheduler if the `RCID` and/or `MCID` of the
-new workload (a process or a VM) is not same as that of the old workload.
+new workload (a process or a VM) is not same as that of the previous workload.
 
 A context switch usually involves saving the context associated with the
 workload being switched away from and restoring the context of the workload
-being switched to. Such a context switch may be invoked in response to an explicit
-call from the workload (i.e, as a function of an `ECALL` invocation) or may be
-done asynchronously (e.g., in response to a timer interrupt). In such cases the
-scheduler may want to execute with the `srmcfg` configuration of the
+being switched to. Such a context switch might be invoked in response to an explicit
+call from the workload (for example, as a function of an `ECALL` invocation) or can be
+done asynchronously (for example, in response to a timer interrupt). In such cases the
+scheduler might want to execute with the `srmcfg` configuration of the
 workload being switched away from such that this execution is attributed to the
 workload being switched away from and then prior to restoring the new workloads
 context, first switch to the `srmcfg` configuration appropriate for the
 workload being switched to such that all of that execution is attributed to
 the new workload. Further in this context switch process, if the scheduler
 intends some of its execution to be attributed to neither the outgoing
-workload nor the incoming workload, then the scheduler may switch to a new
+workload nor the incoming workload, then the scheduler might switch to a new
 `srmcfg` configuration that is different from that of either of the workloads
 for the duration of such execution.
 
@@ -52,7 +52,7 @@ hypervisor. Usually the Guest OS in a virtual machine does not participate in
 the QoS flows as the Guest OS does not know the physical capabilities of the
 platform or the resource allocations for other virtual machines in the system.
 
-If a use case requires it, a hypervisor may virtualize the QoS capability to a
+If a use case requires it, a hypervisor might virtualize the QoS capability to a
 VM by virtualizing the memory-mapped CBQRI register interface and virtualizing
 the virtual-instruction exception on access to `srmcfg` CSR by the Guest OS.
 
@@ -60,7 +60,7 @@ the virtual-instruction exception on access to `srmcfg` CSR by the Guest OS.
 ====
 If the use of directly selecting among a set of `RCID` and/or `MCID` by a VM
 becomes more prevalent and the overhead of virtualizing the `srmcfg` CSR using
-the virtual instruction exception is not acceptable then a future extension may
+the virtual instruction exception is not acceptable then a future extension can
 be introduced where the `RCID`/`MCID` attempted to be written by VS mode are
 used as a selector for a set of `RCID`/`MCID` that the hypervisor configures in
 a set of HS mode CSRs.
@@ -71,21 +71,21 @@ a set of HS mode CSRs.
 The `RCID` and `MCID` configured in `srmcfg` also apply to execution in
 S/HS-mode, but this is typically not an issue. Usually, S/HS-mode execution
 occurs to provide services, such as through an ABI, to software executing at
-lower privilege. Since the S/HS-mode invocation was to provide a service for
-the lower privilege mode, the S/HS-mode software may opt not to modify the
+lower privilege. Because the S/HS-mode invocation provides a service for
+the lower privilege mode, the S/HS-mode software might not opt to modify the
 `srmcfg` CSR.
 
 Similarly, The `RCID` and `MCID` configured in `srmcfg` also apply to execution
 in M-mode, but this is typically not an issue either. Usually, M-mode execution
 occurs to provide services, such as through the SBI interface, to software
-executing at lower privilege. Since the M-mode invocation was to provide a
-service for the lower privilege mode, the M-mode software may opt not to modify
+executing at lower privilege. Because the M-mode invocation provides a
+service for the lower privilege mode, the M-mode software might not opt to modify
 the `srmcfg` CSR.
 
 If separate `RCID` and/or `MCID` are needed during software execution in
-M/S/HS-mode, then the M/S/HS-mode software may update the `srmcfg` CSR and
+M/S/HS-mode, then the M/S/HS-mode software might update the `srmcfg` CSR and
 restore it before returning to lower privilege mode execution. The statistical
 nature of QoS capabilities means that the brief duration, such as the few
 instructions in the M/S/HS-mode trap handler entry point, during which the trap
-handler may execute with the `RCID` and/or `MCID` established for lower
-privilege mode operation may not have a significant statistical impact.
+handler might execute with the `RCID` and/or `MCID` established for lower
+privilege mode operation might not have a significant statistical impact.


### PR DESCRIPTION
Added some edits. Use "can" or "might" rather than "may" because "may" generally indicates permission. I added in a few commas. Finally, if you use the words "this, that, those, or these" you need to have a noun after them. Otherwise, they are hard to translate and also can lead to confusion as to what "this" is referring to.

Also, I found this para in the intro.adoc to be confusing:
The CBQRI registers are defined so that the software can perform two individual 4 byte accesses, or the hardware can perform two independent 4 byte transactions, resulting from an 8 byte access, to the high and low halves of the register as long as the register semantics, with regards to side-effects, are respected between the two software accesses, or two hardware transactions, respectively.

I took out the two clauses. If those clauses are needed, let me know and I'll take another pass.

One of the general complaints that we've gotten for docs is that we do not fully explain the fields in a register. So for example, In qos_bandwidth.adoc after the wavedrom, `VER` and `NBWBLKS` are defined really well. But the descriptions tail off then and I'm not quite sure what `RPFX` and `P` are, even though they are mentioned in paragraph. Not sure what the rest are either. Can you add more description here?  

Same with next register and those in qos_capacity.adoc.

The term `access-type` is used throughout. I changed most of them to be `access-type identifier`. Another choice could be `access type`.  The hyphen makes `access-type` an adjective so it needs a noun. Continuing with this idea. I found `access-type (AT) indicator` in the qos_identifiers.adoc file and `Access-type identifiers` in the qos_intro.adoc file. Are these two different things? 