### PR TITLE
fix typo

### DIFF
--- a/qos_intro.adoc
+++ b/qos_intro.adoc
@@ -19,7 +19,7 @@ to unpredictable workload performance cite:[PTCAMP].
 When multiple workloads are running concurrently on modern processors with large
 core counts, multiple cache hierarchies, and multiple memory controllers, the
 performance of a workload can become less deterministic or even non-deterministic.
-This situation occurs because the worload performance depends on the behavior of the 
+This situation occurs because the workload performance depends on the behavior of the 
 other workloads in the machine that contend for the shared resources, which can lead to
 interference. In many deployment scenarios, such as public cloud servers, the
 workload owner might not be in control of the type and placement of other


### PR DESCRIPTION
Fix a typo in the QoS introduction. Where it says "worload", I believe it should be "workload".